### PR TITLE
v0.1.4-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ return [
 ## Usage
 
 ```php
-use Flavorly\Wallet\Concerns\HasWallet;
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Concerns\InteractsWithWallet;
+use Flavorly\Wallet\Contracts\HasWallet;
 
-class User extends Model implements WalletContract
+class User extends Model implements HasWallet
 {
-    use HasWallet;
+    use InteractsWithWallet;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ return [
     'currency' => 'USD',
     'columns' => [
         'balance' => 'wallet_balance',
-        'decimals' => 'wallet_decimal_places',
-        'currency' => 'wallet_currency',
+        'credit' => 'wallet_credit',
     ]
 ];
 ```

--- a/config/laravel-wallet.php
+++ b/config/laravel-wallet.php
@@ -8,8 +8,6 @@ return [
     // Where it saves the current configuration
     'columns' => [
         'balance' => 'wallet_balance',
-        'decimals' => 'wallet_decimal_places',
-        'currency' => 'wallet_currency',
         'credit' => 'wallet_credit',
     ],
 

--- a/database/migrations/add_transactions_and_wallet.php.stub
+++ b/database/migrations/add_transactions_and_wallet.php.stub
@@ -27,8 +27,6 @@ return new class extends Migration
                 $table->after('remember_token', function (Blueprint $table) {
                     $table->decimal('wallet_balance', 64, 0)->default(0);
                     $table->decimal('wallet_credit', 64, 0)->default(0);
-                    $table->unsignedSmallInteger('wallet_decimal_places')->default(config('laravel-wallet.decimal_places'));
-                    $table->string('wallet_currency')->default(config('laravel-wallet.currency'));
                 });
             });
         }
@@ -41,8 +39,6 @@ return new class extends Migration
             Schema::table($table, function (Blueprint $table) {
                 $table->dropColumn('wallet_balance');
                 $table->dropColumn('wallet_credit');
-                $table->dropColumn('wallet_decimal_places');
-                $table->dropColumn('wallet_currency');
             });
         }
     }

--- a/src/Concerns/InteractsWithTransactions.php
+++ b/src/Concerns/InteractsWithTransactions.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 /**
  * @mixin Model
  */
-trait HasTransactions
+trait InteractsWithTransactions
 {
     /**
      * Get all the transactions for the model.

--- a/src/Concerns/InteractsWithWallet.php
+++ b/src/Concerns/InteractsWithWallet.php
@@ -15,7 +15,7 @@ use Throwable;
 /**
  * @mixin Model
  */
-trait HasWallet
+trait InteractsWithWallet
 {
     protected ?Wallet $wallet = null;
 
@@ -65,6 +65,7 @@ trait HasWallet
                 ->formatTo($this->locale ?? config('app.locale'));
         } catch (Exception $e) {
             report($e);
+
             return '0';
         }
     }
@@ -93,7 +94,6 @@ trait HasWallet
             throw: $throw
         );
     }
-
 
     /**
      * Alias for debit

--- a/src/Contracts/HasTransactions.php
+++ b/src/Contracts/HasTransactions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Flavorly\Wallet\Contracts;
+
+use Flavorly\Wallet\Models\Transaction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+/**
+ * @mixin Model
+ */
+interface HasTransactions
+{
+    /**
+     * Returns all transactions
+     *
+     * @return MorphMany<Transaction>
+     */
+    public function transactions(): MorphMany;
+}

--- a/src/Contracts/HasWallet.php
+++ b/src/Contracts/HasWallet.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 /**
  * @mixin Model
  */
-interface WalletContract
+interface HasWallet
 {
     /**
      * Returns the wallet instance
@@ -33,7 +33,6 @@ interface WalletContract
 
     /**
      * Get the balance formatted as money Value
-     * @return string
      */
     public function getBalanceFormattedAttribute(): string;
 
@@ -53,8 +52,6 @@ interface WalletContract
 
     /**
      * Get the balance service instance
-     *
-     * @return  BalanceService
      */
     public function balance(): BalanceService;
 }

--- a/src/Contracts/WalletContract.php
+++ b/src/Contracts/WalletContract.php
@@ -2,9 +2,9 @@
 
 namespace Flavorly\Wallet\Contracts;
 
-use Brick\Money\Money;
 use Flavorly\LaravelHelpers\Helpers\Math\Math;
 use Flavorly\Wallet\Models\Transaction;
+use Flavorly\Wallet\Services\BalanceService;
 use Flavorly\Wallet\Wallet;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -32,14 +32,10 @@ interface WalletContract
     public function getBalanceAttribute(): Math;
 
     /**
-     * Gets the balance attribute without cache
-     */
-    public function getBalanceWithoutCacheAttribute(): Math;
-
-    /**
      * Get the balance formatted as money Value
+     * @return string
      */
-    public function getBalanceAsMoneyAttribute(): Money;
+    public function getBalanceFormattedAttribute(): string;
 
     /**
      * Credits the user or model with the given amount
@@ -49,14 +45,6 @@ interface WalletContract
     public function credit(float|int|string $amount, array $meta = [], ?string $endpoint = null, bool $throw = false): bool;
 
     /**
-     * Credits the user or model with the given amount
-     * but without any exceptions
-     *
-     * @param  array<string,mixed>  $meta
-     */
-    public function creditQuietly(float|int|string $amount, array $meta = [], ?string $endpoint = null): bool;
-
-    /**
      * Debits the user or model with the given amount
      *
      * @param  array<string,mixed>  $meta
@@ -64,15 +52,9 @@ interface WalletContract
     public function debit(float|int|string $amount, array $meta = [], ?string $endpoint = null, bool $throw = false): bool;
 
     /**
-     * Debits the user or model with the given amount
-     * but without any exceptions
+     * Get the balance service instance
      *
-     * @param  array<string,mixed>  $meta
+     * @return  BalanceService
      */
-    public function debitQuietly(float|int|string $amount, array $meta = [], ?string $endpoint = null): bool;
-
-    /**
-     * Checks if the user has balance for the given amount
-     */
-    public function hasBalanceFor(float|int|string $amount): bool;
+    public function balance(): BalanceService;
 }

--- a/src/Events/TransactionCreatedEvent.php
+++ b/src/Events/TransactionCreatedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Flavorly\Wallet\Events;
 
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Contracts\HasWallet;
 use Flavorly\Wallet\Models\Transaction;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
@@ -14,7 +14,7 @@ class TransactionCreatedEvent
     use SerializesModels;
 
     public function __construct(
-        public WalletContract|Model $model,
+        public HasWallet|Model $model,
         public Transaction $transaction,
     ) {}
 }

--- a/src/Events/TransactionCreditEvent.php
+++ b/src/Events/TransactionCreditEvent.php
@@ -2,7 +2,7 @@
 
 namespace Flavorly\Wallet\Events;
 
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Contracts\HasWallet;
 use Flavorly\Wallet\Models\Transaction;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
@@ -14,7 +14,7 @@ class TransactionCreditEvent
     use SerializesModels;
 
     public function __construct(
-        public WalletContract|Model $model,
+        public HasWallet|Model $model,
         public Transaction $transaction,
     ) {}
 }

--- a/src/Events/TransactionDebitEvent.php
+++ b/src/Events/TransactionDebitEvent.php
@@ -2,7 +2,7 @@
 
 namespace Flavorly\Wallet\Events;
 
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Contracts\HasWallet;
 use Flavorly\Wallet\Models\Transaction;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
@@ -14,7 +14,7 @@ class TransactionDebitEvent
     use SerializesModels;
 
     public function __construct(
-        public WalletContract|Model $model,
+        public HasWallet|Model $model,
         public Transaction $transaction,
     ) {}
 }

--- a/src/Events/TransactionFailedEvent.php
+++ b/src/Events/TransactionFailedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Flavorly\Wallet\Events;
 
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Contracts\HasWallet;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -14,7 +14,7 @@ class TransactionFailedEvent
     use SerializesModels;
 
     public function __construct(
-        public WalletContract|Model $model,
+        public HasWallet|Model $model,
         public bool $credit,
         public int|float|string $amount,
         public Throwable $exception,

--- a/src/Events/TransactionFinishedEvent.php
+++ b/src/Events/TransactionFinishedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Flavorly\Wallet\Events;
 
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Contracts\HasWallet;
 use Flavorly\Wallet\Models\Transaction;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
@@ -14,7 +14,7 @@ class TransactionFinishedEvent
     use SerializesModels;
 
     public function __construct(
-        public WalletContract|Model $model,
+        public HasWallet|Model $model,
         public bool $credit,
         public int|float|string $amount,
         public ?Transaction $transaction = null,

--- a/src/Events/TransactionStartedEvent.php
+++ b/src/Events/TransactionStartedEvent.php
@@ -2,7 +2,7 @@
 
 namespace Flavorly\Wallet\Events;
 
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Contracts\HasWallet;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -13,7 +13,7 @@ class TransactionStartedEvent
     use SerializesModels;
 
     public function __construct(
-        public WalletContract|Model $model,
+        public HasWallet|Model $model,
         public bool $credit,
         public int|float|string $amount,
     ) {}

--- a/src/Helpers/MoneyValueFormatter.php
+++ b/src/Helpers/MoneyValueFormatter.php
@@ -8,7 +8,6 @@ use Brick\Math\Exception\NumberFormatException;
 use Brick\Money\Context\AutoContext;
 use Brick\Money\Money;
 use Flavorly\LaravelHelpers\Helpers\Math\Math;
-use Flavorly\Wallet\Services\ConfigurationService;
 
 final class MoneyValueFormatter
 {
@@ -33,7 +32,7 @@ final class MoneyValueFormatter
     {
         return Money::of(
             $this->toNumber(),
-            ConfigurationService::getCurrency(),
+            $this->currency,
             new AutoContext,
         );
     }

--- a/src/Helpers/MoneyValueFormatter.php
+++ b/src/Helpers/MoneyValueFormatter.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Flavorly\Wallet\Helpers;
+
+use Brick\Math\Exception\DivisionByZeroException;
+use Brick\Math\Exception\MathException;
+use Brick\Math\Exception\NumberFormatException;
+use Brick\Money\Context\AutoContext;
+use Brick\Money\Money;
+use Flavorly\LaravelHelpers\Helpers\Math\Math;
+use Flavorly\Wallet\Services\ConfigurationService;
+
+final class MoneyValueFormatter
+{
+    public function __construct(
+        protected int|float|string $value = 0,
+        protected int $decimals = 10,
+        protected string $currency = 'USD',
+    ) {}
+
+    /**
+     * Get the raw value
+     */
+    public function raw(): int|float|string|null
+    {
+        return $this->value;
+    }
+
+    /**
+     * Get the value as a Money instance
+     */
+    public function toMoney(): Money
+    {
+        return Money::of(
+            $this->toNumber(),
+            ConfigurationService::getCurrency(),
+            new AutoContext,
+        );
+    }
+
+    /**
+     * Get the value as a string
+     */
+    public function toString(): string
+    {
+        return $this->toNumber()->toString();
+    }
+
+    /**
+     * Get the value as a float
+     */
+    public function toFloat(): float
+    {
+        return $this->toNumber()->toFloat();
+    }
+
+    /**
+     * Get the value as a Math instance
+     *
+     * @throws DivisionByZeroException
+     * @throws MathException
+     * @throws NumberFormatException
+     */
+    public function toNumber(): Math
+    {
+        return Math::of(
+            $this->value,
+            $this->decimals,
+            $this->decimals,
+        )->fromStorage();
+    }
+}

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -2,9 +2,27 @@
 
 namespace Flavorly\Wallet\Models;
 
+use Exception;
+use Flavorly\Wallet\Helpers\MoneyValueFormatter;
+use Flavorly\Wallet\Services\ConfigurationService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+/**
+ * @property int $id
+ * @property string $owner_type
+ * @property int $owner_id
+ * @property string|null $subject_type
+ * @property int|null $subject_id
+ * @property bool $credit
+ * @property int|string|float $amount
+ * @property string|null $endpoint
+ * @property array|null $meta
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ *
+ * @mixin \Illuminate\Database\Eloquent\Model
+ */
 class Transaction extends Model
 {
     protected $fillable = [
@@ -26,6 +44,35 @@ class Transaction extends Model
     public function owner(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    /**
+     * Get the value of the transaction as a formatter
+     */
+    public function amount(): MoneyValueFormatter
+    {
+        return new MoneyValueFormatter(
+            $this->amount ?? 0,
+            ConfigurationService::getDecimals(),
+            ConfigurationService::getCurrency(),
+        );
+    }
+
+    /**
+     * Get the balance formatted as money Value
+     */
+    public function getAmountFormattedAttribute(): string
+    {
+        try {
+            return $this
+                ->amount()
+                ->toMoney()
+                ->formatTo('en');
+        } catch (Exception $e) {
+            report($e);
+
+            return $this->amount()->toString();
+        }
     }
 
     /**

--- a/src/Services/BalanceService.php
+++ b/src/Services/BalanceService.php
@@ -3,7 +3,7 @@
 namespace Flavorly\Wallet\Services;
 
 use Flavorly\LaravelHelpers\Helpers\Math\Math;
-use Flavorly\Wallet\Contracts\WalletContract as WalletInterface;
+use Flavorly\Wallet\Contracts\HasWallet as WalletInterface;
 use Flavorly\Wallet\Exceptions\NotEnoughBalanceException;
 use Flavorly\Wallet\Helpers\MoneyValueFormatter;
 use Throwable;

--- a/src/Services/BalanceService.php
+++ b/src/Services/BalanceService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Flavorly\Wallet\Services;
+
+use Flavorly\LaravelHelpers\Helpers\Math\Math;
+use Flavorly\Wallet\Contracts\WalletContract as WalletInterface;
+use Flavorly\Wallet\Exceptions\NotEnoughBalanceException;
+use Flavorly\Wallet\Helpers\MoneyValueFormatter;
+use Throwable;
+
+final class BalanceService
+{
+    /**
+     * Temporary cache for the balance as a static variable
+     * This is used to avoid multiple queries to the database or cache hits
+     * when dealing with the same wallet multiple times in the same request or
+     * for a given process lifecycle
+     */
+    protected null|string|float|int $localCachedRawBalance = null;
+
+    public function __construct(
+        public readonly WalletInterface $model,
+        public readonly CacheService $cache,
+        public readonly ConfigurationService $configuration,
+    ) {}
+
+    /**
+     * Refresh the balance on database & cache if necessary
+     * Also sums all the values from the transactions to get the current balance always calculated
+     * This ensures that the balance is always correct based on previous transactions
+     *
+     * This method also locks before doing any operation to avoid new transactions from
+     * being created while the balance is being updated
+     *
+     * The only exception is when we perform within the transaction itself
+     * the cache()->isWithin() will return true if we are currently performing
+     * a transaction and so we have already applied a lock inside it.
+     */
+    protected function refresh(): void
+    {
+        $closure = function () {
+            // Sum all the balance
+            $balance = $this->model->transactions()->sum('amount');
+
+            // Cache the balance
+            $this->cache->put($balance);
+
+            // Update the balance on database
+            // Quietly as we dont need more events on this one.
+            $this->model->updateQuietly([
+                $this->configuration->getBalanceColumn() => $balance,
+            ]);
+
+            // Update the local variable just in case we need to re-use it
+            $this->localCachedRawBalance = $balance;
+        };
+
+        if ($this->cache->isWithin()) {
+            $closure();
+
+            return;
+        }
+
+        $this->cache->blockAndWrapInTransaction($closure);
+    }
+
+    /**
+     * Returns the balance without any formatting or casting
+     */
+    public function raw(bool $cached = true): int|float|string|null
+    {
+        if (! $cached) {
+            $this->refresh();
+        }
+
+        // If we have a local cached balance, return it
+        if ($this->localCachedRawBalance !== null) {
+            return $this->localCachedRawBalance;
+        }
+
+        if ($this->configuration->getBalanceCachedOnModel()) {
+            $this->localCachedRawBalance = $this->configuration->getBalanceCachedOnModel();
+            $this->cache->put($this->localCachedRawBalance);
+        }
+
+        return $this->localCachedRawBalance ?? '0';
+    }
+
+    /**
+     * Returns the balance as a MoneyValueFormatter instance
+     */
+    public function toFormatter(): MoneyValueFormatter
+    {
+        return new MoneyValueFormatter(
+            $this->raw() ?? 0,
+            ConfigurationService::getDecimals(),
+            ConfigurationService::getCurrency(),
+        );
+    }
+
+    /**
+     * Returns the current balance as a string/float representation
+     * Optional can be the cached balance or the actual balance calculated
+     */
+    public function get(bool $cached = true): Math
+    {
+        return (new MoneyValueFormatter(
+            $this->raw($cached) ?? 0,
+            ConfigurationService::getDecimals(),
+            ConfigurationService::getCurrency(),
+        ))->toNumber();
+    }
+
+    /**
+     * Check if the wallet/model has enough balance for the given amount
+     */
+    public function hasEnoughFor(float|int|string $amount): bool
+    {
+        try {
+            (new OperationService(
+                credit: false,
+                model: $this->model,
+                cache: $this->cache,
+                configuration: $this->configuration,
+                balance: $this,
+            ))
+                ->debit($amount)
+                ->throw(false)
+                ->pretend()
+                ->dispatch();
+
+            return true;
+        } catch (NotEnoughBalanceException $e) {
+            return false;
+        } catch (Throwable $e) {
+            report($e);
+
+            return false;
+        }
+    }
+}

--- a/src/Services/CacheService.php
+++ b/src/Services/CacheService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flavorly\Wallet;
+namespace Flavorly\Wallet\Services;
 
 use Carbon\CarbonImmutable;
 use Flavorly\Wallet\Exceptions\WalletDatabaseTransactionException;

--- a/src/Services/ConfigurationService.php
+++ b/src/Services/ConfigurationService.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Flavorly\Wallet;
+namespace Flavorly\Wallet\Services;
 
-use Brick\Money\Currency;
 use Flavorly\Wallet\Contracts\WalletContract;
 use InvalidArgumentException;
 
@@ -11,7 +10,7 @@ use InvalidArgumentException;
  * We pass the current model to the configuration class
  * So we can grab an additional configuration from the model
  */
-final readonly class Configuration
+final readonly class ConfigurationService
 {
     public function __construct(
         private WalletContract $model,
@@ -20,10 +19,9 @@ final readonly class Configuration
     /**
      * Get the number of decimals to use for the wallet
      */
-    public function getDecimals(): int
+    public static function getDecimals(): int
     {
-        //@phpstan-ignore-next-line
-        $decimals = $this->model->getAttribute(config('laravel-wallet.columns.decimals', 'wallet_decimals')) ?? 10;
+        $decimals = config('laravel-wallet.decimal_places', 10);
         if (is_string($decimals)) {
             return (int) $decimals;
         }
@@ -50,7 +48,7 @@ final readonly class Configuration
     /**
      * Get the Database/Model Balance Attribute
      */
-    public function getBalance(): int|float|string|null
+    public function getBalanceCachedOnModel(): int|float|string|null
     {
         // @phpstan-ignore-next-line
         return $this->model->getAttribute($this->getBalanceColumn());
@@ -68,10 +66,10 @@ final readonly class Configuration
     /**
      * Get the wallet currency, defaults to USD if none provided
      */
-    public function getCurrency(): string
+    public static function getCurrency(): string
     {
         //@phpstan-ignore-next-line
-        return $this->model->getAttribute(config('laravel-wallet.columns.currency', 'wallet_currency')) ?? config('laravel-wallet.currency', 'USD');
+        return config('laravel-wallet.currency', 'USD');
     }
 
     /**

--- a/src/Services/ConfigurationService.php
+++ b/src/Services/ConfigurationService.php
@@ -2,7 +2,7 @@
 
 namespace Flavorly\Wallet\Services;
 
-use Flavorly\Wallet\Contracts\WalletContract;
+use Flavorly\Wallet\Contracts\HasWallet;
 use InvalidArgumentException;
 
 /**
@@ -13,7 +13,7 @@ use InvalidArgumentException;
 final readonly class ConfigurationService
 {
     public function __construct(
-        private WalletContract $model,
+        private HasWallet $model,
     ) {}
 
     /**

--- a/src/Services/OperationService.php
+++ b/src/Services/OperationService.php
@@ -7,7 +7,7 @@ use Closure;
 use Exception;
 use Flavorly\LaravelHelpers\Helpers\Math\Math;
 use Flavorly\Wallet\Concerns\EvaluatesClosures;
-use Flavorly\Wallet\Contracts\WalletContract as WalletInterface;
+use Flavorly\Wallet\Contracts\HasWallet as WalletInterface;
 use Flavorly\Wallet\Events\TransactionCreatedEvent;
 use Flavorly\Wallet\Events\TransactionCreditEvent;
 use Flavorly\Wallet\Events\TransactionDebitEvent;
@@ -401,7 +401,6 @@ final class OperationService
                 $payload['subject_type'] = get_class($this->subject);
             }
 
-            /** @phpstan-ignore-next-line */
             $this->transaction = $this->model->transactions()->create($payload);
 
             // Dispatch Transaction Created Event

--- a/src/Services/OperationService.php
+++ b/src/Services/OperationService.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace Flavorly\Wallet;
+namespace Flavorly\Wallet\Services;
 
 use Brick\Math\Exception\MathException;
 use Closure;
 use Exception;
 use Flavorly\LaravelHelpers\Helpers\Math\Math;
 use Flavorly\Wallet\Concerns\EvaluatesClosures;
+use Flavorly\Wallet\Contracts\WalletContract as WalletInterface;
 use Flavorly\Wallet\Events\TransactionCreatedEvent;
 use Flavorly\Wallet\Events\TransactionCreditEvent;
 use Flavorly\Wallet\Events\TransactionDebitEvent;
@@ -21,7 +22,7 @@ use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Database\Eloquent\Model;
 use Throwable;
 
-final class Operation
+final class OperationService
 {
     use EvaluatesClosures;
 
@@ -100,11 +101,6 @@ final class Operation
     protected bool $processing = false;
 
     /**
-     * Main service interface that contains the wallet data
-     */
-    protected Wallet $wallet;
-
-    /**
      * Stores the transaction if it was successful
      */
     protected ?Transaction $transaction = null;
@@ -114,9 +110,13 @@ final class Operation
      */
     protected ?Model $subject = null;
 
-    public function __construct(Wallet $service, bool $credit)
-    {
-        $this->wallet = $service;
+    public function __construct(
+        bool $credit,
+        public readonly WalletInterface $model,
+        public readonly CacheService $cache,
+        public readonly ConfigurationService $configuration,
+        public readonly BalanceService $balance,
+    ) {
         $this->credit = $credit;
     }
 
@@ -169,8 +169,8 @@ final class Operation
 
         if (Math::of(
             $this->amount,
-            $this->wallet->configuration()->getDecimals(),
-            $this->wallet->configuration()->getDecimals(),
+            ConfigurationService::getDecimals(),
+            ConfigurationService::getDecimals(),
         )->isZero()) {
             throw new InvalidOperationArgumentsException('Amount cannot be zero');
         }
@@ -189,7 +189,7 @@ final class Operation
      * @throws Throwable
      * @throws WalletLockedException
      */
-    public function dispatch(): Operation
+    public function dispatch(): OperationService
     {
         // Ensure everything is set
         $this->ensureWeCanDispatch();
@@ -216,7 +216,7 @@ final class Operation
         } catch (Throwable $e) {
             // Dispatch the failed event
             event(new TransactionFailedEvent(
-                $this->wallet->model,
+                $this->model,
                 $this->credit,
                 $this->amount,
                 $e
@@ -230,7 +230,7 @@ final class Operation
             // Set the processing to false
             //$this->processing = false;
             event(new TransactionFinishedEvent(
-                $this->wallet->model,
+                $this->model,
                 $this->credit,
                 $this->amount,
                 $this->transaction
@@ -253,35 +253,34 @@ final class Operation
         $this->processing = true;
 
         // If the resource is locked, throw an exception instantly
-        if ($this->wallet->cache()->locked()) {
+        if ($this->cache->locked()) {
             throw new WalletLockedException(
                 sprintf(
                     'Resource is locked on Model : %s with Key: %s',
-                    $this->wallet->configuration()->getClass(),
-                    $this->wallet->configuration()->getPrimaryKey()
+                    $this->configuration->getClass(),
+                    $this->configuration->getPrimaryKey()
                 ),
             );
         }
 
         try {
             $this
-                ->wallet
-                ->cache()
+                ->cache
                 ->blockAndWrapInTransaction($callback);
         } catch (LockTimeoutException $e) {
             throw new WalletLockedException(
                 sprintf(
                     'Resource is locked on Model : %s with Key: %s',
-                    $this->wallet->configuration()->getClass(),
-                    $this->wallet->configuration()->getPrimaryKey()
+                    $this->configuration->getClass(),
+                    $this->configuration->getPrimaryKey()
                 ),
             );
         } catch (Exception $e) {
             throw new WalletLockedException(
                 sprintf(
                     'Resource is locked on Model : %s with Key: %s Additional: %s',
-                    $this->wallet->configuration()->getClass(),
-                    $this->wallet->configuration()->getPrimaryKey(),
+                    $this->configuration->getClass(),
+                    $this->configuration->getPrimaryKey(),
                     $e->getMessage(),
                 ),
             );
@@ -303,12 +302,12 @@ final class Operation
             return true;
         }
 
-        $decimals = $this->wallet->configuration()->getDecimals();
+        $decimals = ConfigurationService::getDecimals();
 
-        $balance = $this->wallet->balance();
+        $balance = $this->balance->get();
         $transaction_amount = Math::of($this->amount, $decimals, $decimals)->absolute()->toFloat();
         $difference = Math::of($balance->toFloat(), $decimals, $decimals)->subtract($transaction_amount)->absolute();
-        $credit = Math::of($this->wallet->configuration()->getMaximumCredit(), $decimals, $decimals)->ensureScale()->toFloat();
+        $credit = Math::of($this->configuration->getMaximumCredit(), $decimals, $decimals)->ensureScale()->toFloat();
 
         if ($balance->isLessThan($transaction_amount) && $difference->isLessThanOrEqual($credit)) {
             return true;
@@ -322,7 +321,7 @@ final class Operation
      */
     protected function getAmountForOperation(): string|float|int
     {
-        $decimals = $this->wallet->configuration()->getDecimals();
+        $decimals = ConfigurationService::getDecimals();
 
         return $this->credit
             ? Math::of($this->amount, $decimals, $decimals)->toStorageScale()
@@ -366,12 +365,12 @@ final class Operation
      *
      * @return $this
      */
-    protected function compileDefaultCallbacks(): Operation
+    protected function compileDefaultCallbacks(): OperationService
     {
         // Dispatch a started event
         $this->before(callback: function (): void {
             event(new TransactionStartedEvent(
-                $this->wallet->model,
+                $this->model,
                 $this->credit,
                 $this->amount
             ));
@@ -380,7 +379,7 @@ final class Operation
         // If we should refresh balance cache should be refreshed
         if ($this->shouldRefreshBalance) {
             $this->callback(callback: function () {
-                $this->wallet->balance(cached: false);
+                $this->balance->get(cached: false);
             });
         }
 
@@ -403,19 +402,19 @@ final class Operation
             }
 
             /** @phpstan-ignore-next-line */
-            $this->transaction = $this->wallet->model->transactions()->create($payload);
+            $this->transaction = $this->model->transactions()->create($payload);
 
             // Dispatch Transaction Created Event
             event(new TransactionCreatedEvent(
-                $this->wallet->model,
+                $this->model,
                 $this->transaction
             ));
 
             // Send The Event Based on Credit/Debit
             if ($this->credit) {
-                event(new TransactionCreditEvent($this->wallet->model, $this->transaction));
+                event(new TransactionCreditEvent($this->model, $this->transaction));
             } else {
-                event(new TransactionDebitEvent($this->wallet->model, $this->transaction));
+                event(new TransactionDebitEvent($this->model, $this->transaction));
             }
             unset($payload);
         }, shift: true);
@@ -429,7 +428,7 @@ final class Operation
      *
      * @return $this
      */
-    public function before(?callable $callback, bool $shift = false): Operation
+    public function before(?callable $callback, bool $shift = false): OperationService
     {
         if (! $callback) {
             return $this;
@@ -446,7 +445,7 @@ final class Operation
      *
      * @return $this
      */
-    public function after(?callable $callback, bool $shift = false): Operation
+    public function after(?callable $callback, bool $shift = false): OperationService
     {
         if (! $callback) {
             return $this;
@@ -465,7 +464,7 @@ final class Operation
      *
      * @return $this
      */
-    protected function callback(?callable $callback, bool $shift = false): Operation
+    protected function callback(?callable $callback, bool $shift = false): OperationService
     {
         if (! $callback) {
             return $this;
@@ -481,7 +480,7 @@ final class Operation
      *
      * @return $this
      */
-    public function credit(float|int|string $amount): Operation
+    public function credit(float|int|string $amount): OperationService
     {
         $this->credit = true;
         $this->amount = $amount;
@@ -494,7 +493,7 @@ final class Operation
      *
      * @return $this
      */
-    public function debit(float|int|string $amount): Operation
+    public function debit(float|int|string $amount): OperationService
     {
         $this->credit = false;
         $this->amount = $amount;
@@ -509,7 +508,7 @@ final class Operation
      *
      * @return $this
      */
-    public function if(bool|Closure $condition): Operation
+    public function if(bool|Closure $condition): OperationService
     {
         $this->shouldContinue = (bool) $this->evaluate($condition);
 
@@ -521,7 +520,7 @@ final class Operation
      *
      * @return $this
      */
-    public function pretend(): Operation
+    public function pretend(): OperationService
     {
         return $this->if(false);
     }
@@ -533,7 +532,7 @@ final class Operation
      *
      * @return $this
      */
-    public function throw(bool|Closure $condition = true): Operation
+    public function throw(bool|Closure $condition = true): OperationService
     {
         $this->shouldThrow = (bool) $this->evaluate($condition);
 
@@ -547,7 +546,7 @@ final class Operation
      *
      * @return $this
      */
-    public function endpoint(?string $endpoint = null): Operation
+    public function endpoint(?string $endpoint = null): OperationService
     {
         $this->endpoint = $endpoint;
 
@@ -559,7 +558,7 @@ final class Operation
      *
      * @return $this
      */
-    public function dontThrow(bool|Closure $condition = false): Operation
+    public function dontThrow(bool|Closure $condition = false): OperationService
     {
         $this->shouldThrow = (bool) $this->evaluate($condition);
 
@@ -572,7 +571,7 @@ final class Operation
      * @param  array<string,mixed>  $meta
      * @return $this
      */
-    public function meta(array $meta): Operation
+    public function meta(array $meta): OperationService
     {
         $this->meta = $meta;
 
@@ -586,7 +585,7 @@ final class Operation
      *
      * @return $this
      */
-    public function subject(?Model $subject = null): Operation
+    public function subject(?Model $subject = null): OperationService
     {
         $this->subject = $subject;
 

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -3,7 +3,7 @@
 namespace Flavorly\Wallet;
 
 use Closure;
-use Flavorly\Wallet\Contracts\WalletContract as WalletInterface;
+use Flavorly\Wallet\Contracts\HasWallet as WalletInterface;
 use Flavorly\Wallet\Exceptions\WalletLockedException;
 use Flavorly\Wallet\Services\BalanceService;
 use Flavorly\Wallet\Services\CacheService;
@@ -110,6 +110,8 @@ final class Wallet
 
     /**
      * Credit the user quietly without exceptions
+     *
+     * @param  array<string,mixed>  $meta
      */
     public function creditQuietly(float|int|string $amount, array $meta = [], ?string $endpoint = null): bool
     {
@@ -127,6 +129,8 @@ final class Wallet
 
     /**
      * Debit the user quietly without exceptions
+     *
+     * @param  array<string,mixed>  $meta
      */
     public function debitQuietly(float|int|string $amount, array $meta = [], ?string $endpoint = null): bool
     {
@@ -177,7 +181,7 @@ final class Wallet
     /**
      * Returns the cache service
      */
-    public function cache(int $lockFor = null): CacheService
+    public function cache(?int $lockFor = null): CacheService
     {
         return $this->cache;
     }

--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -2,16 +2,14 @@
 
 namespace Flavorly\Wallet;
 
-use Brick\Math\Exception\NumberFormatException;
-use Brick\Math\Exception\RoundingNecessaryException;
-use Brick\Money\Context\AutoContext;
-use Brick\Money\Exception\UnknownCurrencyException;
-use Brick\Money\Money;
 use Closure;
-use Flavorly\LaravelHelpers\Helpers\Math\Math;
 use Flavorly\Wallet\Contracts\WalletContract as WalletInterface;
-use Flavorly\Wallet\Exceptions\NotEnoughBalanceException;
 use Flavorly\Wallet\Exceptions\WalletLockedException;
+use Flavorly\Wallet\Services\BalanceService;
+use Flavorly\Wallet\Services\CacheService;
+use Flavorly\Wallet\Services\ConfigurationService;
+use Flavorly\Wallet\Services\OperationService;
+use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Database\Eloquent\Model;
 use Throwable;
 
@@ -26,7 +24,7 @@ final class Wallet
      * Stores the configuration for the wallet
      * such as decimals, currency, columns to update etc
      */
-    protected Configuration $configuration;
+    protected ConfigurationService $configuration;
 
     /**
      * Cache service is responsible for caching & locking
@@ -34,12 +32,9 @@ final class Wallet
     protected CacheService $cache;
 
     /**
-     * Temporary cache for the balance as a static variable
-     * This is used to avoid multiple queries to the database or cache hits
-     * when dealing with the same wallet multiple times in the same request or
-     * for a given process lifecycle
+     * Balance Service
      */
-    protected null|string|float|int $localCachedRawBalance = null;
+    protected BalanceService $balance;
 
     /**
      * Bootstrap the class & resolve all necessary services
@@ -48,8 +43,13 @@ final class Wallet
      */
     public function __construct(public readonly WalletInterface $model)
     {
-        $this->configuration = app(Configuration::class, ['model' => $model]);
+        $this->configuration = app(ConfigurationService::class, ['model' => $model]);
         $this->cache = app(CacheService::class, ['prefix' => $model->getKey()]);
+        $this->balance = app(BalanceService::class, [
+            'model' => $model,
+            'cache' => $this->cache,
+            'configuration' => $this->configuration,
+        ]);
     }
 
     /**
@@ -109,143 +109,53 @@ final class Wallet
     }
 
     /**
+     * Credit the user quietly without exceptions
+     */
+    public function creditQuietly(float|int|string $amount, array $meta = [], ?string $endpoint = null): bool
+    {
+        try {
+            return $this->credit(
+                amount: $amount,
+                meta: $meta,
+                endpoint: $endpoint,
+                throw: true
+            );
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Debit the user quietly without exceptions
+     */
+    public function debitQuietly(float|int|string $amount, array $meta = [], ?string $endpoint = null): bool
+    {
+        try {
+            return $this->debit(
+                amount: $amount,
+                meta: $meta,
+                endpoint: $endpoint,
+                throw: true
+            );
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
      * Creates a new operation
      * This is the main entry point to create transaction
      * Wallet class is just an API for the actual underlying operation object
      */
-    public function operation(bool $credit): Operation
+    public function operation(bool $credit): OperationService
     {
-        return new Operation($this, $credit);
-    }
-
-    /**
-     * Refresh the balance on database & cache if necessary
-     * Also sums all the values from the transactions to get the current balance always calculated
-     * This ensures that the balance is always correct based on previous transactions
-     *
-     * This method also locks before doing any operation to avoid new transactions from
-     * being created while the balance is being updated
-     *
-     * The only exception is when we perform within the transaction itself
-     * the cache()->isWithin() will return true if we are currently performing
-     * a transaction and so we have already applied a lock inside it.
-     */
-    protected function refreshBalance(): void
-    {
-        $closure = function () {
-            // Sum all the balance
-            $balance = $this->model->transactions()->sum('amount');
-
-            // Cache the balance
-            $this->cache->put($balance);
-
-            // Update the balance on database
-            // Quietly as we dont need more events on this one.
-            $this->model->updateQuietly([
-                $this->configuration->getBalanceColumn() => $balance,
-            ]);
-
-            // Update the local variable just in case we need to re-use it
-            $this->localCachedRawBalance = $balance;
-        };
-
-        if ($this->cache->isWithin()) {
-            $closure();
-
-            return;
-        }
-
-        $this->cache->blockAndWrapInTransaction($closure);
-    }
-
-    /**
-     * Returns the cache service
-     */
-    public function cache(): CacheService
-    {
-        return $this->cache;
-    }
-
-    /**
-     * Returns the wallet configuration
-     */
-    public function configuration(): Configuration
-    {
-        return $this->configuration;
-    }
-
-    /**
-     * Returns the current balance as a string/float representation
-     * Optional can be the cached balance or the actual balance calculated
-     */
-    public function balance(bool $cached = true): Math
-    {
-        return Math::of(
-            $this->balanceRaw($cached) ?? 0,
-            $this->configuration()->getDecimals(),
-            $this->configuration()->getDecimals(),
-        )->fromStorage();
-    }
-
-    /**
-     * Returns the balance without any formatting or casting
-     */
-    public function balanceRaw(bool $cached = true): int|float|string|null
-    {
-        if (! $cached) {
-            $this->refreshBalance();
-        }
-
-        // If we have a local cached balance, return it
-        if ($this->localCachedRawBalance !== null) {
-            return $this->localCachedRawBalance;
-        }
-
-        if ($this->configuration->getBalance()) {
-            $this->localCachedRawBalance = $this->configuration->getBalance();
-            $this->cache()->put($this->localCachedRawBalance);
-        }
-
-        return $this->localCachedRawBalance ?? '0';
-    }
-
-    /**
-     * Return the current Balance as a Money instance
-     *
-     * @throws NumberFormatException
-     * @throws RoundingNecessaryException
-     * @throws UnknownCurrencyException
-     */
-    public function balanceAsMoney(): Money
-    {
-        return Money::of(
-            $this->balance()->toNumber(),
-            $this->configuration->getCurrency(),
-            new AutoContext,
+        return new OperationService(
+            $credit,
+            $this->model,
+            $this->cache,
+            $this->configuration,
+            $this->balance,
         );
-    }
-
-    /**
-     * Check if the wallet/model has enough balance for the given amount
-     */
-    public function hasBalanceFor(float|int|string $amount): bool
-    {
-        try {
-            $this
-                ->operation(false)
-                ->debit($amount)
-                ->throw(false)
-                ->pretend()
-                ->dispatch();
-
-            return true;
-        } catch (NotEnoughBalanceException $e) {
-            return false;
-        } catch (Throwable $e) {
-            report($e);
-
-            return false;
-        }
     }
 
     /**
@@ -254,5 +164,29 @@ final class Wallet
     public function locked(): bool
     {
         return $this->cache->locked();
+    }
+
+    /**
+     * Get the lock instance but without blocking ( yet )
+     */
+    public function lock(?int $lockFor = null): Lock
+    {
+        return $this->cache->lock($lockFor);
+    }
+
+    /**
+     * Returns the cache service
+     */
+    public function cache(int $lockFor = null): CacheService
+    {
+        return $this->cache;
+    }
+
+    /**
+     * Returns the balance service
+     */
+    public function balance(): BalanceService
+    {
+        return $this->balance;
     }
 }


### PR DESCRIPTION
- Removed Decimal places & currency from the user/wallet, currency and decimals are now global, since it didnt made any sense to have per-wallet decimals/currency for the current usage of the wallet
- Added a Value formatter that formats both transaction and balance
- Split the Balance Service from the Wallet Service, so we can have nicer fluent ways to interact with the balance and also format it.
- Remove the wallet from the Operation deps, now each service should be injected.
- Rename to Traits & Contracts to align with Laravel Standards
- Move creditQuietly and debitQuietly to the Wallet Service instead of the trait.